### PR TITLE
Filling up the water bar causes fish duplication

### DIFF
--- a/app/src/main/java/com/hydrofish/app/HydroFishViewModel.kt
+++ b/app/src/main/java/com/hydrofish/app/HydroFishViewModel.kt
@@ -2,6 +2,7 @@ package com.hydrofish.app
 
 import androidx.lifecycle.ViewModel
 import com.hydrofish.app.ui.HydroFishUIState
+import com.hydrofish.app.ui.composables.FishType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -11,14 +12,31 @@ class HydroFishViewModel: ViewModel() {
     // backing property to avoid updates from other classes
     private val _uiState = MutableStateFlow(HydroFishUIState())
     val uiState: StateFlow<HydroFishUIState> = _uiState.asStateFlow()
-
+    private fun generateSequentialFloatList(size: Int, range: ClosedFloatingPointRange<Float>): List<Float> {
+        val step = (range.endInclusive - range.start) / (size - 1)
+        return List(size) { index -> range.start + step * index }
+    }
     fun increaseWaterLevel(amt: Float) {
-        _uiState.update {
-            currentState -> currentState.copy(
-                dailyWaterConsumedML = amt + currentState.dailyWaterConsumedML
-            )
+        val willSurpassLimit = uiState.value.dailyWaterConsumedML + amt >= uiState.value.curDailyMaxWaterConsumedML;
+        val hasSurpassedLimit = uiState.value.dailyWaterConsumedML >= uiState.value.curDailyMaxWaterConsumedML;
+
+        if (willSurpassLimit && !hasSurpassedLimit) {
+            val newList = uiState.value.fishTypeList
+            newList.add(FishType.FISH_V1);
+            _uiState.update { currentState ->
+                currentState.copy(
+                    dailyWaterConsumedML = amt + currentState.dailyWaterConsumedML,
+                    fishDistances = generateSequentialFloatList(uiState.value.fishTypeList.size, 100f..600f),
+                    fishTypeList = newList
+                )
+            }
+        } else {
+            _uiState.update { currentState ->
+                currentState.copy(
+                    dailyWaterConsumedML = amt + currentState.dailyWaterConsumedML,
+                )
+            }
         }
     }
-    
 }
 

--- a/app/src/main/java/com/hydrofish/app/ui/HydroFishUIState.kt
+++ b/app/src/main/java/com/hydrofish/app/ui/HydroFishUIState.kt
@@ -1,7 +1,11 @@
 package com.hydrofish.app.ui
 
+import com.hydrofish.app.ui.composables.FishType
+
 data class HydroFishUIState(
     val dailyWaterConsumedML: Float = 0f,
-    val curDailyMaxWaterConsumedML: Float = 1000f
+    val curDailyMaxWaterConsumedML: Float = 1000f,
+    val fishTypeList: MutableList<FishType> = mutableListOf(FishType.FISH_V1, FishType.FISH_V1),
+    var fishDistances: List<Float> = listOf(300f, 500f)
 )
 

--- a/app/src/main/java/com/hydrofish/app/ui/composables/tabs/HomeScreen.kt
+++ b/app/src/main/java/com/hydrofish/app/ui/composables/tabs/HomeScreen.kt
@@ -54,10 +54,8 @@ val largeRadialGradient = object : ShaderBrush() {
 }
 
 // initialize fishList with two fish and distance list
-val fishTypeList = mutableListOf(FishType.FISH_V1, FishType.FISH_V1)
-var fishDistances = listOf(300f, 500f)
-var barFull = true
-
+//val fishTypeList = mutableListOf(FishType.FISH_V1, FishType.FISH_V1)
+//var fishDistances = listOf(300f, 500f)
 
 @Composable
 fun HomeScreen(modifier: Modifier, hydroFishViewModel: HydroFishViewModel = viewModel()) {
@@ -71,8 +69,7 @@ fun HomeScreen(modifier: Modifier, hydroFishViewModel: HydroFishViewModel = view
         contentAlignment = Alignment.Center,
 
         ) {
-        AddFish(modifier = Modifier, barFull)
-        DisplayFish(modifier = Modifier, fishes = fishTypeList, distances = fishDistances)
+        DisplayFish(modifier = Modifier, fishes = hydroFishUIState.fishTypeList, distances = hydroFishUIState.fishDistances)
 
         AddProgessBar(modifier.align(Alignment.CenterEnd), waterPercent)
 
@@ -98,24 +95,8 @@ fun AddProgessBar(modifier: Modifier, waterConsumed: Float) {
     }
 }
 
-fun generateSequentialFloatList(size: Int, range: ClosedFloatingPointRange<Float>): List<Float> {
-    val step = (range.endInclusive - range.start) / (size - 1)
-    return List(size) { index -> range.start + step * index }
-}
-
-@Composable
-fun AddFish (modifier: Modifier, barFull: Boolean){
-    if (barFull) {
-        fishTypeList.add(FishType.FISH_V1)
-        fishDistances = generateSequentialFloatList(fishTypeList.size, 100f..600f)
-    }
-}
-
-
-
 @Composable
 fun DisplayFish(modifier: Modifier, fishes: List<FishType>, distances: List<Float>) {
-
     if (fishes.size == distances.size) {
         fishes.forEachIndexed { index, fishType ->
             val direction: Boolean = Random.nextBoolean()

--- a/app/src/main/java/com/hydrofish/app/ui/composables/tabs/HomeScreen.kt
+++ b/app/src/main/java/com/hydrofish/app/ui/composables/tabs/HomeScreen.kt
@@ -53,10 +53,6 @@ val largeRadialGradient = object : ShaderBrush() {
     }
 }
 
-// initialize fishList with two fish and distance list
-//val fishTypeList = mutableListOf(FishType.FISH_V1, FishType.FISH_V1)
-//var fishDistances = listOf(300f, 500f)
-
 @Composable
 fun HomeScreen(modifier: Modifier, hydroFishViewModel: HydroFishViewModel = viewModel()) {
     //This approach ensures that whenever there is a change in the uiState value,


### PR DESCRIPTION
If you fill up the bar by clicking any of the buttons, 2 fish will duplicate into 3 fish
The screen should flash and fish will be shifted to account for the third fish (expected behaviour)

Closes #14 